### PR TITLE
Disallow updating of an existing installation

### DIFF
--- a/FreenetInstall_InnoSetup.iss
+++ b/FreenetInstall_InnoSetup.iss
@@ -300,3 +300,22 @@ begin
   if (PageID = JavaDependency.Page.ID) And fCheckJavaInstall() then Result := True;
   if (PageID = NetDependency.Page.ID) And IsNetInstalled() then Result := True;
 end;
+
+function IsFreenetInstalled(): Boolean;
+var
+  RegPath: String;
+begin
+  Result := False;
+  RegPath := ExpandConstant('Software\Microsoft\Windows\CurrentVersion\Uninstall\{#emit SetupSetting("AppId")}_is1');
+  if RegValueExists(HKLM, RegPath, 'UninstallString') or RegValueExists(HKCU, RegPath, 'UninstallString')
+  then Result := True;
+end;
+
+function InitializeSetup(): Boolean;
+begin
+  Result := True;
+  if (IsFreenetInstalled()) then begin
+    Result := False;
+    MsgBox(CustomMessage('FreenetAlreadyInstalled'), mbCriticalError, MB_OK);
+  end;
+end;

--- a/translations/Messages_en.isl
+++ b/translations/Messages_en.isl
@@ -8,6 +8,7 @@ DependencyInstalled=%1 has been installed on your system.
 ErrorLaunchDependencyInstaller=Can't launch %1 installer.%n%nError (%2): %3.
 AdditionalOptions=Additional options:
 StartFreenetWithWindows=Start Freenet when I log in to Windows
+FreenetAlreadyInstalled=An existing Freenet installation is found. This installer cannot be used to update Freenet to a newer version. To update, enable Freenet's built-in automatic updates or run 'update.cmd' from the installation directory. To re-install, please uninstall Freenet first.
 
 [Messages]
 WelcomeLabel2=This will install [name/ver] on your computer.

--- a/translations/Messages_en_utf8.isl
+++ b/translations/Messages_en_utf8.isl
@@ -8,6 +8,7 @@ DependencyInstalled=%1 has been installed on your system.
 ErrorLaunchDependencyInstaller=Can't launch %1 installer.%n%nError (%2): %3.
 AdditionalOptions=Additional options:
 StartFreenetWithWindows=Start Freenet when I log in to Windows
+FreenetAlreadyInstalled=An existing Freenet installation is found. This installer cannot be used to update Freenet to a newer version. To update, enable Freenet's built-in automatic updates or run 'update.cmd' from the installation directory. To re-install, please uninstall Freenet first.
 
 [Messages]
 WelcomeLabel2=This will install [name/ver] on your computer.


### PR DESCRIPTION
The installer cannot reliably be used to update an existing
installation, especially when dependencies have been updated: it does
not properly update wrapper.conf, breaking existing installations.

This exits the setup immediately when an existing Freenet installation
is found, displaying an error message to the user.

This requires the InnoSetup preprocessor (ISPP). I have tested this on Wine and it appears to work.
