### PR TITLE
Reference bundled zip for extraction

### DIFF
--- a/FreenetInstall_InnoSetup.iss
+++ b/FreenetInstall_InnoSetup.iss
@@ -61,11 +61,10 @@ Name: "traditional_chinese"; MessagesFile: ".\unofficial\ChineseTraditional.isl,
 
 [Files]
 Source: "FreenetInstaller_InnoSetup_library\FreenetInstaller_InnoSetup_library.dll"; DestDir: "{tmp}"; Flags: ignoreversion dontcopy
-Source: "install_bundle\jre-8u261-windows-i586.exe"; DestDir: "{tmp}"; Flags: ignoreversion dontcopy
-Source: "install_bundle\jre-10.0.2_windows-x64_bin.zip"; DestDir: "{tmp}"; Flags: ignoreversion dontcopy
-Source: "install_bundle\dotNetFx40_Full_setup.exe"; DestDir: "{tmp}"; Flags: ignoreversion dontcopy
-#include "fred_deps.iss"
-Source: "install_node\FreenetTray.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "install_bundle\jre-8u261-windows-i586.exe"; DestDir: "{tmp}"; Flags: ignoreversion dontcopy nocompression
+Source: "install_bundle\jre-10.0.2_windows-x64_bin.zip"; DestDir: "{tmp}"; Flags: ignoreversion dontcopy nocompression
+Source: "install_bundle\dotNetFx40_Full_setup.exe"; DestDir: "{tmp}"; Flags: ignoreversion dontcopy nocompression
+Source: "install_node\FreenetTray.exe"; DestDir: "{app}"; Flags: ignoreversion nocompression
 Source: "install_node\FreenetTray.exe.config"; DestDir: "{app}"; Flags: ignoreversion
 Source: "install_node\freenet.ico"; DestDir: "{app}"; Flags: ignoreversion
 Source: "install_node\freenetoffline.ico"; DestDir: "{app}"; Flags: ignoreversion
@@ -85,8 +84,8 @@ Source: "install_node\updater\sha1test.jar"; DestDir: "{app}\updater"; Flags: ig
 Source: "install_node\updater\startssl.pem"; DestDir: "{app}\updater"; Flags: ignoreversion
 Source: "install_node\updater\update.cmd"; DestDir: "{app}\updater"; Flags: ignoreversion
 Source: "install_node\updater\wget.exe"; DestDir: "{app}\updater"; Flags: ignoreversion
-Source: "install_node\wrapper\freenetwrapper.exe"; DestDir: "{app}\wrapper"; Flags: ignoreversion
-Source: "install_node\wrapper\freenetwrapper-64.exe"; DestDir: "{app}\wrapper"; Flags: ignoreversion
+Source: "install_node\wrapper\freenetwrapper.exe"; DestDir: "{app}\wrapper"; Flags: ignoreversion nocompression
+Source: "install_node\wrapper\freenetwrapper-64.exe"; DestDir: "{app}\wrapper"; Flags: ignoreversion nocompression
 Source: "install_node\wrapper\wrapper.jar"; DestDir: "{app}\wrapper"; Flags: ignoreversion
 Source: "install_node\wrapper\wrapper-windows-x86-32.dll"; DestDir: "{app}\wrapper"; Flags: ignoreversion
 Source: "install_node\wrapper\wrapper-windows-x86-64.dll"; DestDir: "{app}\wrapper"; Flags: ignoreversion
@@ -291,17 +290,15 @@ procedure ButtonInstallJavaOnClick(Sender: TObject);
 var
   ErrorCode : Integer;
   sErrorCode: string;
-  sJavaInstallerZip: string;
   sJavaInstaller: string;
   ButtonInstallJava: TNewButton;
 begin
   ButtonInstallJava := TNewButton (Sender);
   ButtonInstallJava.Enabled := False;
   if (isWin64()) then begin
-    sJavaInstallerZip := '{tmp}\jre-10.0.2_windows-x64_bin.zip';
     ShellExec(
         'runas',
-        Format('unzip %s -d %s', [ExpandConstant(sJavaInstallerZip), ExpandConstant('{tmp}')]),
+        ExpandConstant('unzip {tmp}\jre-10.0.2_windows-x64_bin.zip -d {tmp}'),
         '',
         '',
         SW_SHOW,

--- a/FreenetInstall_InnoSetup.iss
+++ b/FreenetInstall_InnoSetup.iss
@@ -299,7 +299,7 @@ begin
   ButtonInstallJava.Enabled := False;
   if (isWin64()) then begin
     sJavaInstallerZip := '{tmp}\jre-10.0.2_windows-x64_bin.zip';
-    ShellExec('runas','unzip',ExpandConstant(sJavaInstaller),'-d',ExpandConstant('{tmp}\'),SW_SHOW,ewWaitUntilTerminated,ErrorCode)
+    ShellExec('runas','unzip',ExpandConstant(sJavaInstallerZip),'-d',ExpandConstant('{tmp}\'),SW_SHOW,ewWaitUntilTerminated,ErrorCode)
     sJavaInstaller := '{tmp}\jre-10.0.2_windows-x64_bin.exe';
   end else begin
     sJavaInstaller := '{tmp}\jre-8u261-windows-i586.exe';

--- a/FreenetInstall_InnoSetup.iss
+++ b/FreenetInstall_InnoSetup.iss
@@ -299,7 +299,15 @@ begin
   ButtonInstallJava.Enabled := False;
   if (isWin64()) then begin
     sJavaInstallerZip := '{tmp}\jre-10.0.2_windows-x64_bin.zip';
-    ShellExec('runas','unzip',ExpandConstant(sJavaInstallerZip),'-d',ExpandConstant('{tmp}\'),SW_SHOW,ewWaitUntilTerminated,ErrorCode)
+    ShellExec(
+        'runas',
+        Format('unzip %s -d %s', [ExpandConstant(sJavaInstallerZip), ExpandConstant('{tmp}')]),
+        '',
+        '',
+        SW_SHOW,
+        ewWaitUntilTerminated,
+        ErrorCode
+    );
     sJavaInstaller := '{tmp}\jre-10.0.2_windows-x64_bin.exe';
   end else begin
     sJavaInstaller := '{tmp}\jre-8u261-windows-i586.exe';

--- a/FreenetInstall_InnoSetup.iss
+++ b/FreenetInstall_InnoSetup.iss
@@ -64,6 +64,7 @@ Source: "FreenetInstaller_InnoSetup_library\FreenetInstaller_InnoSetup_library.d
 Source: "install_bundle\jre-8u261-windows-i586.exe"; DestDir: "{tmp}"; Flags: ignoreversion dontcopy nocompression
 Source: "install_bundle\jre-10.0.2_windows-x64_bin.zip"; DestDir: "{tmp}"; Flags: ignoreversion dontcopy nocompression
 Source: "install_bundle\dotNetFx40_Full_setup.exe"; DestDir: "{tmp}"; Flags: ignoreversion dontcopy nocompression
+#include "fred_deps.iss"
 Source: "install_node\FreenetTray.exe"; DestDir: "{app}"; Flags: ignoreversion nocompression
 Source: "install_node\FreenetTray.exe.config"; DestDir: "{app}"; Flags: ignoreversion
 Source: "install_node\freenet.ico"; DestDir: "{app}"; Flags: ignoreversion


### PR DESCRIPTION
Fixed the issue with the bundled zip and also remove unnecessary compression reducing compilation from 30s to 2s.

Using docker image:  amake/innosetup from https://github.com/amake/innosetup-docker. Executable size: 173 MB.
```
$ docker run --rm -i -v "$PWD:/work" amake/innosetup FreenetInstall_InnoSetup.iss
...
Successful compile (2.941 sec). Resulting Setup program filename is:
Z:\work\Output\FreenetInstaller.exe
```

