### PR TITLE
Pre-unpack jre zip before creating installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
 
     - uses: eskatos/gradle-command-action@v1
       with:
+        arguments: unzip
+
+
+    - uses: eskatos/gradle-command-action@v1
+      with:
         arguments: updateSetupFile
 
     - name: Building the installer

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.gradle
 /fred_deps.iss
 /fred_version.iss
+*_bin.exe

--- a/FreenetInstall_InnoSetup.iss
+++ b/FreenetInstall_InnoSetup.iss
@@ -62,7 +62,7 @@ Name: "traditional_chinese"; MessagesFile: ".\unofficial\ChineseTraditional.isl,
 [Files]
 Source: "FreenetInstaller_InnoSetup_library\FreenetInstaller_InnoSetup_library.dll"; DestDir: "{tmp}"; Flags: ignoreversion dontcopy
 Source: "install_bundle\jre-8u261-windows-i586.exe"; DestDir: "{tmp}"; Flags: ignoreversion dontcopy nocompression
-Source: "install_bundle\jre-10.0.2_windows-x64_bin.zip"; DestDir: "{tmp}"; Flags: ignoreversion dontcopy nocompression
+Source: "install_bundle\jre-10.0.2_windows-x64_bin.exe"; DestDir: "{tmp}"; Flags: ignoreversion dontcopy nocompression
 Source: "install_bundle\dotNetFx40_Full_setup.exe"; DestDir: "{tmp}"; Flags: ignoreversion dontcopy nocompression
 #include "fred_deps.iss"
 Source: "install_node\FreenetTray.exe"; DestDir: "{app}"; Flags: ignoreversion nocompression
@@ -297,15 +297,6 @@ begin
   ButtonInstallJava := TNewButton (Sender);
   ButtonInstallJava.Enabled := False;
   if (isWin64()) then begin
-    ShellExec(
-        'runas',
-        ExpandConstant('unzip {tmp}\jre-10.0.2_windows-x64_bin.zip -d {tmp}'),
-        '',
-        '',
-        SW_SHOW,
-        ewWaitUntilTerminated,
-        ErrorCode
-    );
     sJavaInstaller := '{tmp}\jre-10.0.2_windows-x64_bin.exe';
   end else begin
     sJavaInstaller := '{tmp}\jre-8u261-windows-i586.exe';

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,14 @@ task buildInfo {
     }
 }
 
+task unzip(type: Copy) {
+    // since your zip is in the buildDir, I suppose you'll need deferred evaluation, hence the from(Closure) variant
+    from {
+        zipTree("install_bundle/jre-10.0.2_windows-x64_bin.zip").singleFile
+    }
+    into "install_bundle"
+}
+
 task updateSetupFile {
 	doLast {
 		def file = new File("fred_version.iss")


### PR DESCRIPTION
Overcome github file size limit by packing jre as a .zip (already done) and unzipping it _before_ creating the innosetup installer. 

```
 Successful compile (7.797 sec). Resulting Setup program filename is:
D:\a\wininstaller-innosetup\wininstaller-innosetup\Output\FreenetInstaller.exe

```