### PR TITLE
CI: some fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
 
     - name: Unzip and update setup file
       run: |
-        gradle unzip
-        gradle updateSetupFile
+        .\gradlew.bat unzip
+        .\gradlew.bat updateSetupFile
 
     - name: Building the installer
       run: |


### PR DESCRIPTION
- Use latest version of Actions
- Use PowerShell features to get freenet.jar, reduces dependency
- Use official Gradle Actions to setup Gradle
- Remove no-longer needed sign sections